### PR TITLE
Remove (and flag obsolete) the grok-ruby subpackage

### DIFF
--- a/grok.spec.template
+++ b/grok.spec.template
@@ -15,18 +15,12 @@ Requires: pcre >= 7.6
 Requires: tokyocabinet >= 1.4.9
 BuildRequires: ruby-devel libevent-devel gperf tokyocabinet-devel pcre-devel
 
+# no longer needed -- modern jls-grok gem uses libffi
+Obsoletes: grok-ruby
+
 %description
 A powerful pattern matching system for parsing and processing text data such
 as log files.
-
-%package ruby
-Group: System Environment/Utilities
-Summary: Ruby library to access grok functions
-Requires: ruby >= 1.8.5
-Requires: grok = %{version}-%{release}
-
-%description ruby
-A ruby interface to the grok pattern matching library.
 
 %package devel
 Group: Development Tools
@@ -41,29 +35,18 @@ Headers required for grok development.
 %build
 make
 
-# for the ruby extention
-export LD_LIBRARY_PATH=$PWD
-cd ruby
-ruby ext/extconf.rb
-make
-cd ..
-
 %install
 %{__rm} -rf %{buildroot}
 %{__mkdir_p} %{buildroot}%{_bindir}
 %{__mkdir_p} %{buildroot}%{_libdir}
 %{__mkdir_p} %{buildroot}%{_includedir}
 %{__mkdir_p} %{buildroot}%{_sharedir}/patterns
-%{__mkdir_p} %{buildroot}%{ruby_sitearchdir}
 install -c grok %{buildroot}/%{_bindir}
 install -c libgrok.so %{buildroot}/%{_libdir}
 install -c patterns/base %{buildroot}%{_sharedir}/patterns/base
 for header in grok.h grok_pattern.h grok_capture.h grok_capture_xdr.h grok_match.h grok_logging.h grok_discover.h grok_version.h; do
  install -c $header %{buildroot}/%{_includedir}
 done
-cd ruby
-make install DESTDIR=%{buildroot}
-cd ..
 
 %clean
 %{__rm} -rf %{buildroot}
@@ -75,9 +58,6 @@ cd ..
 %dir %{_sharedir}
 %dir %{_sharedir}/patterns
 %{_sharedir}/patterns/base
-
-%files ruby
-%{ruby_sitearchdir}/Grok.so
 
 %files devel
 %{_includedir}


### PR DESCRIPTION
While the ruby extension code still exists in git, it isn't actually needed any more, and doesn't appear to build anyhow (on account of a missing makefile).

This removes the extension from the spec file, and tells RPM it can remove the obsolete package from the system of anyone who installing a newer grok.
