### PR TITLE
Fixed uname flag order for OsX compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PACKAGE=grok
 
-PLATFORM=$(shell (uname -o || uname -s) | tr -d "/" 2> /dev/null)
+PLATFORM=$(shell (uname -s || uname -o) | tr -d "/" 2> /dev/null)
 FLEX?=flex
 
 FORCE_FLEX?=0


### PR DESCRIPTION
This allows the makefile to work on osx (10.7.2).  Uname on Osx does not have the -o flag and errors when called.
