### PR TITLE
[fix] grok is not working anymore with PCRE >= 8.34

### DIFF
--- a/grokre.c
+++ b/grokre.c
@@ -12,8 +12,8 @@
 
 /* global, static variables */
 
-#define CAPTURE_ID_LEN 4
-#define CAPTURE_FORMAT "%04x"
+#define CAPTURE_ID_LEN 5
+#define CAPTURE_FORMAT "_%04x"
 
 /* internal functions */
 static char *grok_pattern_expand(grok_t *grok); //, int offset, int length);


### PR DESCRIPTION
 because the latter does not allow anymore a group name to start with digits (PCRE Changelog version 8.34, point 36)

this commit fix the issue by prepending a '_' at the start of group name.
It remains compatible with older versions of PCRE

example (running with samples/strpredicate.grok)
*before*:
```
$> ./grok  -f samples/strpredicate.grok 
Failure compiling pattern '%{WORD $> test}': group name must start with a non-digit
```
*after*
```
$> ./grok  -f samples/strpredicate.grok 
Found: world
```