### PR TITLE
Add pattern delete functionality to grok

### DIFF
--- a/grok_pattern.c
+++ b/grok_pattern.c
@@ -49,6 +49,10 @@ int grok_pattern_find(const grok_t *grok, const char *name, size_t name_len,
   return GROK_OK;
 }
 
+bool grok_pattern_delete(const grok_t *grok, const char *name, size_t name_len) {
+  return tctreeout(grok->patterns, name, name_len);
+}
+
 int grok_patterns_import_from_file(const grok_t *grok, const char *filename) {
   FILE *patfile = NULL;
   size_t filesize = 0;

--- a/grok_pattern.h
+++ b/grok_pattern.h
@@ -12,7 +12,7 @@ int grok_pattern_find(const grok_t *grok, const char *name, size_t name_len,
                       const char **regexp, size_t *regexp_len);
 int grok_patterns_import_from_file(const grok_t *grok, const char *filename);
 int grok_patterns_import_from_string(const grok_t *grok, const char *buffer);
-
+bool grok_pattern_delete(const grok_t *grok, const char *name, size_t name_len);
 /* Exposed only for testing */
 void _pattern_parse_string(const char *line,
                            const char **name, size_t *name_len,


### PR DESCRIPTION
Adding grok_pattern_delete into grok_pattern_add.h/c allows users to delete a defined grok pattern. tctreeout would do the job and handle the case in which patterns are not defined.