### PR TITLE
Resolve ctags ambiguity for ubuntu

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,7 +19,7 @@ Dependencies:
       CUnit        >= 2.1
 
     Ubuntu dependency list (for ease):
-      apt-get install bison ctags flex gperf libevent-dev libpcre3-dev libtokyocabinet-dev
+      apt-get install bison universal-ctags flex gperf libevent-dev libpcre3-dev libtokyocabinet-dev
 
 Building:
   make grok    (or 'gmake grok' if your make is not gnu make)


### PR DESCRIPTION
apt returns with

```Package ctags is a virtual package provided by:
  universal-ctags 0+git20200824-1
  exuberant-ctags 1:5.9~svn20110310-13
You should explicitly select one to install.
```
universal-ctags appears to be the active package.