### PR TITLE
Fix implicit declaration of conf_new_patternfile

### DIFF
--- a/grok_config.h
+++ b/grok_config.h
@@ -21,6 +21,7 @@ struct config {
 
 void conf_init(struct config *conf);
 void conf_new_program(struct config *conf);
+void conf_new_patternfile(struct config *conf);
 void conf_new_input(struct config *conf);
 void conf_new_input_process(struct config *conf, char *cmd);
 void conf_new_input_file(struct config *conf, char *filename);


### PR DESCRIPTION
Fixes:
```
conf.y:86:7: error: implicit declaration of function 'conf_new_patternfile' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    { conf_new_patternfile(conf); CURPATTERNFILE = (yyvsp[(3) - (3)].str); ;}
      ^
```
