### PR TITLE
Include grok_config.h before conf.tab.h

### DIFF
--- a/conf.lex
+++ b/conf.lex
@@ -1,7 +1,7 @@
 %{
 #include <string.h>
-#include "conf.tab.h"
 #include "grok_config.h"
+#include "conf.tab.h"
 #include "stringhelper.h"
 %}
 

--- a/conf.y
+++ b/conf.y
@@ -2,8 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "conf.tab.h"
 #include "grok_config.h"
+#include "conf.tab.h"
 #include "grok_input.h"
 #include "grok_matchconf.h"
 


### PR DESCRIPTION
[Paul Eggert explained on the bison mailing list](https://lists.gnu.org/archive/html/bug-bison/2022-01/msg00013.html):

> This is because grok's #include order is messed up. conf.y includes conf.tab.h (which uses the type struct config) before it includes grok_config.h (which defines the type). C requires declaration before use, so it should include the files in the other order. Some compilers will go ahead and compile anyway, depending on their flags; others won't.

Fixes:

```
conf.tab.c:1302:1: error: conflicting types for 'yyparse'
yyparse (struct config *conf)
^
conf.tab.h:116:5: note: previous declaration is here
```
