### PR TITLE
Add yylex prototype

### DIFF
--- a/conf.y
+++ b/conf.y
@@ -12,6 +12,8 @@ void yyerror (YYLTYPE *loc, struct config *conf, char const *s) {
   fprintf (stderr, "Syntax error: %s\n", s);
 }
 
+int yylex (YYSTYPE *lvalp, YYLTYPE *llocp);
+
 #define DEBUGMASK(val) ((val > 0) ? ~0 : 0)
 %}
 


### PR DESCRIPTION
Fixes:

```
conf.tab.c:1429:16: error: implicit declaration of function 'yylex' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      yychar = YYLEX;
               ^
conf.tab.c:745:16: note: expanded from macro 'YYLEX'
# define YYLEX yylex (&yylval, &yylloc)
               ^
```

I don't know bison and I do not know if this is the best fix for this issue. [On the bison mailing list Paul Eggert said](https://lists.gnu.org/archive/html/bug-bison/2022-01/msg00013.html) that the prototype should be

> in an include file that both conf.lex and conf.y include so that they both agree with the declaration

and I have not attempted to do that here so you may want to do that instead.

I have also read about a define called `YY_DECL`; I don't know if that would be relevant in this circumstance.

I figure since you know bison well enough to have written a program using it, you will know how best to resolve this issue.